### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,3 +31,74 @@ jobs:
         run: |
           export FORCE_COLOR=1
           ./dcmon --static-once dcmon-test ./examples/checks.yaml
+
+  # Decide if a release is necessary, do any release linting/checks
+  check-release:
+    needs: [ compose-tests ]
+    name: Check Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref, '.')
+    outputs:
+      RELEASE_VERSION: ${{ steps.get-version.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with: { submodules: 'recursive', fetch-depth: 0 }
+
+      - id: get-version
+        name: Get release version
+        run: |
+          echo "RELEASE_VERSION=$(jq -r .version package.json)" | tee "$GITHUB_ENV" | tee "$GITHUB_OUTPUT"
+
+      - name: Check git tag matches release version
+        run: |
+          [ "refs/tags/v${RELEASE_VERSION}" == "${{ github.ref }}" ]
+
+  release-npm:
+    needs: [ check-release ]
+    name: Release NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with: { submodules: 'recursive', fetch-depth: 0 }
+
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: ''
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  release-docker-hub:
+    needs: [ check-release ]
+    name: Release Docker Hub
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_VERSION: ${{ needs.check-release.outputs.RELEASE_VERSION }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with: { submodules: 'recursive', fetch-depth: 0 }
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: lonocloud/dcmon:${{ env.RELEASE_VERSION }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: lonocloud/dcmon:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as build
+FROM node:20 AS build
 
 RUN apt-get -y update && \
     apt-get -y install default-jdk-headless
@@ -17,7 +17,7 @@ RUN cd /app && \
     chmod +x build/*.js
 
 
-FROM node:16-slim as run
+FROM node:20-slim AS run
 
 COPY --from=build /app/ /app/
 


### PR DESCRIPTION
These changes will automatically do NPM and Docker Hub releases, when we push a git tag of the form 'vX.Y.Z'. Before we release, we run all tests and verify the git tag matches our package.json.

Additionally, update the node version used in the Docker image, and fix up the FromAsCasing issue/warning.