### PR TITLE
Workaround empty status event field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "dcmon",
       "version": "1.6.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {

--- a/src/dcmon/core.cljc
+++ b/src/dcmon/core.cljc
@@ -506,7 +506,7 @@ Options:
                    nil))
         status (:status evt)
         init? (= "start" status)]
-    (when (not= "exec_" (.substr status 0 5))
+    (when (and status (not= "exec_" (.substr status 0 5)))
       (if verbose-events
         (event :docker-event evt)
         (event :docker-event (select-keys evt [:id :status])))


### PR DESCRIPTION
An upgrade of docker desktop (docker engine 29.1.2) means that sometimes we get emtpy status fields in events after running check commands. Instead of crashing, just ignore those events/messages.